### PR TITLE
Fix Fixnum

### DIFF
--- a/hiccup.gemspec
+++ b/hiccup.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "builder"
 
   s.add_development_dependency "ri_cal"
-  s.add_development_dependency "bundler", "~> 1.10"
+  s.add_development_dependency "bundler"
   s.add_development_dependency "rake", "~> 10.0"
   s.add_development_dependency "minitest-reporters"
   s.add_development_dependency "minitest-reporters-turn_reporter"

--- a/lib/hiccup/core_ext/integer.rb
+++ b/lib/hiccup/core_ext/integer.rb
@@ -1,4 +1,4 @@
-class Fixnum
+class Integer
 
   # todo: complete
   def human_ordinalize(map={})

--- a/lib/hiccup/enumerable/monthly_enumerator.rb
+++ b/lib/hiccup/enumerable/monthly_enumerator.rb
@@ -7,7 +7,7 @@ module Hiccup
       def self.for(schedule)
         if schedule.monthly_pattern.empty?
           NeverEnumerator
-        elsif schedule.monthly_pattern.all? { |occurrence| Fixnum === occurrence }
+        elsif schedule.monthly_pattern.all? { |occurrence| Integer === occurrence }
           MonthlyDateEnumerator
         else
           self

--- a/lib/hiccup/humanizable.rb
+++ b/lib/hiccup/humanizable.rb
@@ -1,5 +1,5 @@
 require "hiccup/convenience"
-require "hiccup/core_ext/fixnum"
+require "hiccup/core_ext/integer"
 
 
 module Hiccup

--- a/lib/hiccup/validatable.rb
+++ b/lib/hiccup/validatable.rb
@@ -68,10 +68,10 @@ module Hiccup
     def valid_occurrence?(occurrence)
       if occurrence.is_a?(Array)
         i, wd = occurrence
-        Date::DAYNAMES.member?(wd) && i.is_a?(Fixnum) && ((i == -1) || (1..6).include?(i))
+        Date::DAYNAMES.member?(wd) && i.is_a?(Integer) && ((i == -1) || (1..6).include?(i))
       else
         i = occurrence
-        i.is_a?(Fixnum) && ([-1] + (1..31).to_a).include?(i)
+        i.is_a?(Integer) && ([-1] + (1..31).to_a).include?(i)
       end
     end
 
@@ -86,7 +86,7 @@ module Hiccup
     #     ordinal, kind = occurrence
     #
     #     errors.add(:kind, "is not a valid monthly occurrence kind") unless Date::DAYNAMES.member?(kind)
-    #     if ordinal.is_a?(Fixnum)
+    #     if ordinal.is_a?(Integer)
     #       errors.add(:ordinal, "is not a valid integer") unless (ordinal==-1) or (1..6).include?(ordinal)
     #     else
     #       errors.add(:ordinal, "is not an integer")
@@ -94,7 +94,7 @@ module Hiccup
     #   else
     #     ordinal = occurrence
     #
-    #     if ordinal.is_a?(Fixnum)
+    #     if ordinal.is_a?(Integer)
     #       errors.add(:ordinal, "is not an integer between 1 and 31") unless (1..31).include?(ordinal)
     #     else
     #       errors.add(:ordinal, "is not an integer")


### PR DESCRIPTION
### Summary
`Fixnum` is deprecated, so this opts to use `Integer` instead.